### PR TITLE
Run with sql auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ A GitHub Action that takes in a list of dependency scripts for a database, downl
 | `db-name`                 | true        | N/A     | The name of the database where the dependency files will run.                                                                                            |
 | `dependency-list`         | true        | N/A     | A json string containing a list of objects with the name of the dependency package, the version, and the url where the package is stored.                |
 | `use-integrated-security` | true        | false   | Use domain integrated security. If false, a db-username and db-password should be specified. If true, those parameters will be ignored if specified.     |
-| `username`                | true        | N/A     | The username to use to login to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.         |
-| `password`                | true        | N/A     | The password for the user logging in to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored. |
+| `db-username`             | false       | N/A     | The username to use to login to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.         |
+| `db-password`             | false       | N/A     | The password for the user logging in to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored. |
 
 The `dependency-list` should be an array of objects with the following properties:
 ```json

--- a/README.md
+++ b/README.md
@@ -4,19 +4,24 @@ A GitHub Action that takes in a list of dependency scripts for a database, downl
 
 ## Index
  
-- [Inputs](#inputs)
-- [Example](#example)
-- [Contributing](#contributing)
-	- [Incrementing the Version](#incrementing-the-version)
-- [Code of Conduct](#code-of-conduct)
-- [License](#license)    
+- [install-and-run-db-dependency-scripts](#install-and-run-db-dependency-scripts)
+  - [Index](#index)
+  - [Inputs](#inputs)
+  - [Example](#example)
+  - [Contributing](#contributing)
+    - [Incrementing the Version](#incrementing-the-version)
+  - [Code of Conduct](#code-of-conduct)
+  - [License](#license)
 
 ## Inputs
-| Parameter         | Is Required | Description                                                                                                                               |
-| ----------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `db-server-name`  | true        | The server where the dependency files will be run.                                                                                        |
-| `db-name`         | true        | The name of the database where the dependency files will run.                                                                             |
-| `dependency-list` | true        | A json string containing a list of objects with the name of the dependency package, the version, and the url where the package is stored. |
+| Parameter                 | Is Required | Default | Description                                                                                                                                              |
+| ------------------------- | ----------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `db-server-name`          | true        | N/A     | The server where the dependency files will be run.                                                                                                       |
+| `db-name`                 | true        | N/A     | The name of the database where the dependency files will run.                                                                                            |
+| `dependency-list`         | true        | N/A     | A json string containing a list of objects with the name of the dependency package, the version, and the url where the package is stored.                |
+| `use-integrated-security` | true        | false   | Use domain integrated security. If false, a db-username and db-password should be specified. If true, those parameters will be ignored if specified.     |
+| `username`                | true        | N/A     | The username to use to login to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.         |
+| `password`                | true        | N/A     | The password for the user logging in to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored. |
 
 The `dependency-list` should be an array of objects with the following properties:
 ```json

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
           orgs: 'my-org'
 
       - name: Download and Run Dependencies
-        uses: im-open/install-and-run-db-dependency-scripts@v1.0.1
+        uses: im-open/install-and-run-db-dependency-scripts@v1.2.0
         with:
           db-server-name: 'localhost,1433'
           db-name: 'LocalDb'

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,15 @@ inputs:
   dependency-list:
     description: A json string containing a list of objects with the name of the dependency package, the version, and the url where the package is stored.
     required: true
+  use-integrated-security:
+    description: Use domain integrated security. If false, a db-username and db-password should be specified. If true, those parameters will be ignored if specified.
+    required: true
+    default: 'false'
   username:
-    description: The username of the sql account to use when running the dependency scripts. Integrated security will be used if this isn't specified
+    description: The username to use to login to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.
     required: false
   password:
-    description: The password of the sql account to use when running the dependency scripts.
+    description: The password for the user logging in to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.
     required: false
 
 runs:
@@ -36,5 +40,6 @@ runs:
         ${{ github.action_path }}\src\run-db-dependencies.ps1 `
           -dbServer "${{ inputs.db-server-name }}" `
           -dbName "${{ inputs.db-name }}" `
+          -useIntegratedSecurity:$${{ inputs.use-integrated-security }} `
           -username "${{ inputs.username }}" `
           -password $securePassword

--- a/action.yml
+++ b/action.yml
@@ -16,10 +16,10 @@ inputs:
     description: Use domain integrated security. If false, a db-username and db-password should be specified. If true, those parameters will be ignored if specified.
     required: true
     default: 'false'
-  username:
+  db-username:
     description: The username to use to login to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.
     required: false
-  password:
+  db-password:
     description: The password for the user logging in to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.
     required: false
 
@@ -35,11 +35,11 @@ runs:
     - name: Run DB Dependencies
       shell: pwsh
       run: |
-        [System.Security.SecureString] $securePassword = if(!!"${{ inputs.password }}") { ConvertTo-SecureString "${{ inputs.password }}" -AsPlainText -Force } else { $null }
+        [System.Security.SecureString] $securePassword = if(!!"${{ inputs.db-password }}") { ConvertTo-SecureString "${{ inputs.password }}" -AsPlainText -Force } else { $null }
 
         ${{ github.action_path }}\src\run-db-dependencies.ps1 `
           -dbServer "${{ inputs.db-server-name }}" `
           -dbName "${{ inputs.db-name }}" `
           -useIntegratedSecurity:$${{ inputs.use-integrated-security }} `
-          -username "${{ inputs.username }}" `
+          -username "${{ inputs.db-username }}" `
           -password $securePassword

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,15 @@ inputs:
   dependency-list:
     description: A json string containing a list of objects with the name of the dependency package, the version, and the url where the package is stored.
     required: true
+  username:
+    description: The username of the sql account to use when running the dependency scripts. Integrated security will be used if this isn't specified
+    required: false
+  password:
+    description: The password of the sql account to use when running the dependency scripts.
+    required: false
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Install DB Dependencies
       shell: pwsh
@@ -24,4 +30,11 @@ runs:
 
     - name: Run DB Dependencies
       shell: pwsh
-      run: ${{ github.action_path }}\src\run-db-dependencies.ps1 -dbServer "${{ inputs.db-server-name }}" -dbName "${{ inputs.db-name }}"
+      run: |
+        [System.Security.SecureString] $securePassword = if(!!"${{ inputs.password }}") { ConvertTo-SecureString "${{ inputs.password }}" -AsPlainText -Force } else { $null }
+
+        ${{ github.action_path }}\src\run-db-dependencies.ps1 `
+          -dbServer "${{ inputs.db-server-name }}" `
+          -dbName "${{ inputs.db-name }}" `
+          -username "${{ inputs.username }}" `
+          -password $securePassword

--- a/src/run-db-dependencies.ps1
+++ b/src/run-db-dependencies.ps1
@@ -43,16 +43,6 @@ Get-ChildItem -Path $dependencyFolder -Recurse -Depth 1 -Filter *.sql | ForEach-
     $paramsAsAString = [string]::Join(" ", $dependencyFileParams)
 
     Invoke-Expression -Command "Invoke-Sqlcmd $paramsAsAString"
-    # Invoke-Sqlcmd `
-    #     -InputFile $_.FullName `
-    #     -ServerInstance $dbServer `
-    #     -Database $dbName `
-    #     -Username $username `
-    #     -Password $password `
-    #     -AbortOnError `
-    #     -SeverityLevel 0 `
-    #     -ErrorLevel 0 `
-    #     -Verbose
 }
 
 Write-Host "Finished running database dependency scripts"

--- a/src/run-db-dependencies.ps1
+++ b/src/run-db-dependencies.ps1
@@ -1,6 +1,7 @@
 param (
     [string]$dbServer,
     [string]$dbName,
+    [switch]$useIntegratedSecurity = $false,
     [string]$username,
     [securestring]$password
 )
@@ -25,14 +26,11 @@ $temp = @("Invoke-Sqlcmd $temp2")
 
 Write-Host $temp
 
-if ($null -ne $username) {
-    $sqlCmdParams += "-Username $username"
-}
-
-if ($null -ne $password) {
+if (!$useIntegratedSecurity) {
     $cred = New-Object System.Management.Automation.PSCredential -ArgumentList $username, $password
     $plainPassword = $cred.GetNetworkCredential().Password
 
+    $sqlCmdParams += "-Username $username"
     $sqlCmdParams += "-Password $plainPassword"
 }
 

--- a/src/run-db-dependencies.ps1
+++ b/src/run-db-dependencies.ps1
@@ -12,13 +12,18 @@ $dependencyFolder = "$PSScriptRoot\.dependencies"
 Import-Module SqlServer
 
 $sqlCmdParams = @(
-    "-ServerInstance $dbServer"
-    "-Database $dbName"
+    "-ServerInstance `"$dbServer`""
+    "-Database `"$dbName`""
     "-AbortOnError"
     "-SeverityLevel 0"
     "-ErrorLevel 0"
     "-Verbose"
 )
+
+$temp2 = [string]::Join(" ", $sqlCmdParams)
+$temp = @("Invoke-Sqlcmd $temp2")
+
+Write-Host $temp
 
 if ($null -ne $username) {
     $sqlCmdParams += "-Username $username"
@@ -34,7 +39,7 @@ if ($null -ne $password) {
 Get-ChildItem -Path $dependencyFolder -Recurse -Depth 1 -Filter *.sql | ForEach-Object {
     Write-Host "Running $($_.Name)"
 
-    $dependencyFileParams = @("-InputFile $_.FullName") + $sqlCmdParams
+    $dependencyFileParams = @("-InputFile $($_.FullName)") + $sqlCmdParams
     $paramsAsAString = [string]::Join(" ", $dependencyFileParams)
 
     Invoke-Expression -Command "Invoke-Sqlcmd $paramsAsAString"

--- a/src/run-db-dependencies.ps1
+++ b/src/run-db-dependencies.ps1
@@ -1,6 +1,8 @@
 param (
     [string]$dbServer,
-    [string]$dbName
+    [string]$dbName,
+    [string]$username,
+    [securestring]$password
 )
 
 Write-Host "Running database dependency scripts"


### PR DESCRIPTION
# Summary of PR changes

Allowing the use of SQL Auth instead of strictly domain integrated security. This will open up the ability to run the action on more than just Windows runners.

## PR Requirements
- [X] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [X] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [X] The action code does not contain sensitive information.
