### PR TITLE
Add auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
 
       - name: Download and Run Dependencies
         # You may also reference the major or major.minor version
-        uses: im-open/install-and-run-db-dependency-scripts@v1.1.2
+        uses: im-open/install-and-run-db-dependency-scripts@v1.2.0
         with:
           db-server-name: 'localhost,1433'
           db-name: 'LocalDb'

--- a/README.md
+++ b/README.md
@@ -15,14 +15,15 @@ A GitHub Action that takes in a list of dependency scripts for a database, downl
 
 ## Inputs
 
-| Parameter                 | Is Required | Default | Description                                                                                                                                                                                        |
-| ------------------------- | ----------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `db-server-name`          | true        | N/A     | The server where the dependency files will be run.                                                                                                                                                 |
-| `db-name`                 | true        | N/A     | The name of the database where the dependency files will run.                                                                                                                                      |
-| `dependency-list`         | true        | N/A     | A json string containing a list of objects with the name of the dependency package, the version,the url where the package is stored, and optionally the auth token needed to download the package. |
-| `use-integrated-security` | true        | false   | Use domain integrated security. If false, a db-username and db-password should be specified. If true, those parameters will be ignored if specified.                                               |
-| `db-username`             | false       | N/A     | The username to use to login to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.                                                   |
-| `db-password`             | false       | N/A     | The password for the user logging in to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.                                           |
+| Parameter                  | Is Required | Default | Description                                                                                                                                                                                        |
+| -------------------------- | ----------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `db-server-name`           | true        | N/A     | The server where the dependency files will be run.                                                                                                                                                 |
+| `db-name`                  | true        | N/A     | The name of the database where the dependency files will run.                                                                                                                                      |
+| `dependency-list`          | true        | N/A     | A json string containing a list of objects with the name of the dependency package, the version,the url where the package is stored, and optionally the auth token needed to download the package. |
+| `use-integrated-security`  | true        | false   | Use domain integrated security. If false, a db-username and db-password should be specified. If true, those parameters will be ignored if specified.                                               |
+| `db-username`              | false       | N/A     | The username to use to login to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.                                                   |
+| `db-password`              | false       | N/A     | The password for the user logging in to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.                                           |
+| `trust-server-certificate` | false       | false   | A boolean that controls whether or not to validate the SQL Server TLS certificate.                                                                                                                 |
 
 The `dependency-list` should be an array of objects with the following properties:
 
@@ -59,6 +60,7 @@ jobs:
         with:
           db-server-name: 'localhost,1433'
           db-name: 'LocalDb'
+          trust-server-certificate: 'true'
           dependency-list: '[{"version":"1.0.0","packageName":"dbo.Something","nugetUrl":"https://nuget.pkg.github.com/my-org/download/Something/1.0.0/dbo.Something.1.0.0.nupkg","authToken":"ghp_dkfsjakldafl"},{"version":"1.2.0","packageName":"dbo.SomeOtherThing","nugetUrl":"https://nuget.pkg.github.com/my-org/download/SomeOtherThing/1.2.0/dbo.SomeOtherThing1.2.0.nupkg","authToken":"ghp_dkfsjakldafl"}]'
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ A GitHub Action that takes in a list of dependency scripts for a database, downl
 
 ## Inputs
 
-| Parameter                 | Is Required | Default | Description                                                                                                                                              |
-| ------------------------- | ----------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `db-server-name`          | true        | N/A     | The server where the dependency files will be run.                                                                                                       |
-| `db-name`                 | true        | N/A     | The name of the database where the dependency files will run.                                                                                            |
-| `dependency-list`         | true        | N/A     | A json string containing a list of objects with the name of the dependency package, the version, and the url where the package is stored.                |
-| `use-integrated-security` | true        | false   | Use domain integrated security. If false, a db-username and db-password should be specified. If true, those parameters will be ignored if specified.     |
-| `db-username`             | false       | N/A     | The username to use to login to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.         |
-| `db-password`             | false       | N/A     | The password for the user logging in to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored. |
+| Parameter                 | Is Required | Default | Description                                                                                                                                                                                        |
+| ------------------------- | ----------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `db-server-name`          | true        | N/A     | The server where the dependency files will be run.                                                                                                                                                 |
+| `db-name`                 | true        | N/A     | The name of the database where the dependency files will run.                                                                                                                                      |
+| `dependency-list`         | true        | N/A     | A json string containing a list of objects with the name of the dependency package, the version,the url where the package is stored, and optionally the auth token needed to download the package. |
+| `use-integrated-security` | true        | false   | Use domain integrated security. If false, a db-username and db-password should be specified. If true, those parameters will be ignored if specified.                                               |
+| `db-username`             | false       | N/A     | The username to use to login to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.                                                   |
+| `db-password`             | false       | N/A     | The password for the user logging in to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.                                           |
 
 The `dependency-list` should be an array of objects with the following properties:
 
@@ -30,9 +30,14 @@ The `dependency-list` should be an array of objects with the following propertie
 {
   "version": "1.0.0",
   "packageName": "some_package",
-  "nugetUrl": "https://www.some-nuget-repo.com"
+  "nugetUrl": "https://www.some-nuget-repo.com",
+  "authToken": "ghp_fdijlfdsakeizdkliejfezejw"
 }
 ```
+
+**Notes** 
+* The `authToken` property is optionally used for nuget sources that require a bearer token, such as GitHub Packages. It should not be included if it is unnecessary.
+* The `nugetUrl` for GitHub Packages can be pretty tricky to lookup, so for reference the pattern is as follows: `https://nuget.pkg.github.com/<owner>/download/<package-name>/<version>/<file-name>.nupkg`. Here's an example of how that could look if this repo were publishing a package called `MyDbObject`: `https://nuget.pkg.github.com/im-open/download/MyDbObject/1.0.0/MyDbObject.1.0.0.nupkg`.
 
 ## Example
 
@@ -54,7 +59,7 @@ jobs:
         with:
           db-server-name: 'localhost,1433'
           db-name: 'LocalDb'
-          dependency-list: '[{"version":"1.0.0","packageName":"dbo.Something","nugetUrl":"https://nuget.pkg.github.com/my-org/my-repo/dbo.Something.nupkg"},{"version":"1.2.0","packageName":"dbo.SomeOtherThing","nugetUrl":"https://nuget.pkg.github.com/my-org/my-repo/dbo.SomeOtherThing.nupkg"}]'
+          dependency-list: '[{"version":"1.0.0","packageName":"dbo.Something","nugetUrl":"https://nuget.pkg.github.com/my-org/download/Something/1.0.0/dbo.Something.1.0.0.nupkg","authToken":"ghp_dkfsjakldafl"},{"version":"1.2.0","packageName":"dbo.SomeOtherThing","nugetUrl":"https://nuget.pkg.github.com/my-org/download/SomeOtherThing/1.2.0/dbo.SomeOtherThing1.2.0.nupkg","authToken":"ghp_dkfsjakldafl"}]'
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
   db-password:
     description: The password for the user logging in to the database. This is required if use-integrated-security is false, otherwise it's optional and will be ignored.
     required: false
+  trust-server-certificate:
+    description: A boolean that controls whether or not to validate the SQL Server TLS certificate.
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -42,4 +46,5 @@ runs:
           -dbName "${{ inputs.db-name }}" `
           -useIntegratedSecurity:$${{ inputs.use-integrated-security }} `
           -username "${{ inputs.db-username }}" `
-          -password $securePassword
+          -password $securePassword `
+          -trustServerCertificate:$${{ inputs.trust-server-certificate }}

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: The name of the database where the dependency files will run.
     required: true
   dependency-list:
-    description: A json string containing a list of objects with the name of the dependency package, the version, and the url where the package is stored.
+    description: A json string containing a list of objects with the name of the dependency package, the version,the url where the package is stored, and optionally the auth token needed to download the package.
     required: true
   use-integrated-security:
     description: Use domain integrated security. If false, a db-username and db-password should be specified. If true, those parameters will be ignored if specified.

--- a/src/download-db-dependencies.ps1
+++ b/src/download-db-dependencies.ps1
@@ -2,54 +2,59 @@ param(
     [PSCustomObject[]]$dependencies
 )
 
-if ($null -eq $dependencies -or !$dependencies.PSobject.Properties.name.Contains("Count" ) -or $dependencies.Count -eq 0)
-{
+if ($null -eq $dependencies -or !$dependencies.PSobject.Properties.name.Contains("Count") -or $dependencies.Count -eq 0) {
     return
 }
 
 Write-Host "Downloading database objects"
 
-$nugetFolder = "$PSScriptRoot\.nuget"
-$dependencyOutputFolder = "$PSScriptRoot\.dependencies"
-$targetNugetExe = "$nugetFolder\nuget.exe"
-$sourceNugetExe = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+$dependencyOutputFolder = "$PSScriptRoot/.dependencies"
 
-if (![System.IO.File]::Exists($targetNugetExe))
-{
-    Write-Host "Downloading nuget.exe"
-    New-Item -ItemType Directory -Path $nugetFolder
-    Invoke-WebRequest $sourceNugetExe -OutFile $targetNugetExe
-}
-
-if (-Not (Test-Path $dependencyOutputFolder))
-{
+if (-Not (Test-Path $dependencyOutputFolder)) {
     New-Item -ItemType Directory -Path $dependencyOutputFolder
 }
 
-foreach ($dependency in $dependencies)
-{
+foreach ($dependency in $dependencies) {
     #Download Package
     $packageName = $dependency.packageName
     $version = $dependency.version
     $url = $dependency.nugetUrl
-    $nugetOutput = "$dependencyOutputFolder\$packageName.nupkg"
+    $nugetOutput = "$dependencyOutputFolder/$packageName.nupkg"
+
+    $headers = If ($dependency.authToken) { @{ "Authorization" = "Bearer $($dependency.authToken)" } } Else { @{} };
     Write-Host "Downloading $packageName.$version"
     Remove-Item $nugetOutput -Force -Recurse -ErrorAction Ignore
 
-    try
-    {
-        Invoke-WebRequest $url -OutFile $nugetOutput
+    try {
+        Invoke-WebRequest $url -OutFile $nugetOutput -Headers $headers
     }
-    catch
-    {
+    catch {
         Write-Error $_;
     }
 
     #Extract Package
-    $extractionLocation = "$dependencyOutputFolder\$packageName"
+    $extractionLocation = "$dependencyOutputFolder/$packageName"
     Remove-Item $extractionLocation -Force -Recurse -ErrorAction Ignore
+    New-Item -ItemType Directory -Path $extractionLocation
     Add-Type -AssemblyName System.IO.Compression.FileSystem
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($nugetOutput, $extractionLocation)
+
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($nugetOutput)
+
+    foreach ($item in $zip.Entries) {
+        $itemDirectory = Join-Path -Path $extractionLocation -ChildPath (Split-Path -parent $item.FullName)
+        
+        try {
+            if ($itemDirectory -and -not (Test-Path $itemDirectory)) {
+                New-Item -ItemType Directory -Path $itemDirectory
+            }
+            [System.IO.Compression.ZipFileExtensions]::ExtractToFile($item, (Join-Path -Path $extractionLocation -ChildPath $item.FullName), $false)
+        }
+        catch {
+            # Write out any errors that happen but continue on
+            Write-Host "An error occurred. Writing out the information and moving on."
+            Write-Host $_
+        }
+    }
 }
 
 Write-Host "Finished downloading database objects"

--- a/src/run-db-dependencies.ps1
+++ b/src/run-db-dependencies.ps1
@@ -3,7 +3,8 @@ param (
     [string]$dbName,
     [switch]$useIntegratedSecurity = $false,
     [string]$username,
-    [securestring]$password
+    [securestring]$password,
+    [switch]$trustServerCertificate
 )
 
 Write-Host "Running database dependency scripts"
@@ -20,6 +21,10 @@ $sqlCmdParams = @(
     "-ErrorLevel 0"
     "-Verbose"
 )
+
+if ($trustServerCertificate) {
+    $sqlCmdParams += "-TrustServerCertificate"
+}
 
 $temp2 = [string]::Join(" ", $sqlCmdParams)
 $temp = @("Invoke-Sqlcmd $temp2")


### PR DESCRIPTION
# Summary of PR changes

* Allowing the passing of an authentication token to use when downloading an artifact.
* Adding the `trust-server-certificate` flag that gets passed through to the `Invoke-SqlCmd` call when running dependency scripts.

## PR Requirements
- [X] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [X] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
